### PR TITLE
Fix URLs for tutorials and hyper repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 <hr>
 
 Hypertrout lets you build [Hyper](https://hyper.wickstrom.tech) web servers on
-top of the [purescript-trout](https://github.com/owickstrom/purescript-trout)
+top of the [purescript-trout](https://github.com/purescript-hyper/purescript-trout)
 API for type-level routing.
 
 ## Usage
 
 For the documentation on how to use this package, please see [the
-tutorials](https://owickstrom.github.io/purescript-hypertrout/).
+tutorials](https://purescript-hyper.github.io/purescript-hypertrout/).
 
 There are also [runnable examples in this repository](examples/).
 


### PR DESCRIPTION
It seems like this project has moved and the links weren't updated