### PR TITLE
Bump dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,32 +3,33 @@ language: node_js
 sudo: false
 
 node_js:
-- '11'
+  - "11"
 
 env:
   matrix:
-  - PATH=$HOME:$HOME/purescript:$PATH
+    - PATH=$HOME:$HOME/purescript:$PATH
 
 install:
-- PURS_VER=v0.13.2
-- SPAGO_VER=0.8.5.0
-- wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$PURS_VER/linux64.tar.gz
-- wget -O $HOME/spago.tar.gz https://github.com/spacchetti/spago/releases/download/0.8.5.0/linux.tar.gz
-- tar -xvf $HOME/purescript.tar.gz -C $HOME/
-- tar -xvf $HOME/spago.tar.gz -C $HOME/
-- chmod a+x $HOME/purescript/purs
-- chmod a+x $HOME/spago
-- npm install -g bower@^1.8.8 pulp@^13.0.0
-- spago install
-- bower install
+  - PURS_VER=v0.13.8
+  - SPAGO_VER=0.15.3
+  - PULP_VER=15.0.0
+  - wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$PURS_VER/linux64.tar.gz
+  - wget -O $HOME/spago.tar.gz https://github.com/purescript/spago/releases/download/$SPAGO_VER/linux.tar.gz
+  - tar -xvf $HOME/purescript.tar.gz -C $HOME/
+  - tar -xvf $HOME/spago.tar.gz -C $HOME/
+  - chmod a+x $HOME/purescript/purs
+  - chmod a+x $HOME/spago
+  - npm install -g bower@^1.8.8 pulp@^$PULP_VER
+  - spago install
+  - bower install
 
 script:
-- export VERSION=branch-job-$TRAVIS_JOB_NUMBER
-- if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then export VERSION=pull-request-job-$TRAVIS_JOB_NUMBER;
-  fi
-- if [[ "$TRAVIS_TAG" != "" ]]; then export VERSION=$TRAVIS_TAG; fi
-- spago build
-- spago test
-- make examples docs-examples
-- rm -rf .spago output
-- pulp build
+  - export VERSION=branch-job-$TRAVIS_JOB_NUMBER
+  - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then export VERSION=pull-request-job-$TRAVIS_JOB_NUMBER;
+    fi
+  - if [[ "$TRAVIS_TAG" != "" ]]; then export VERSION=$TRAVIS_TAG; fi
+  - spago build
+  - spago test
+  - make examples docs-examples
+  - rm -rf .spago output
+  - pulp build

--- a/bower.json
+++ b/bower.json
@@ -5,26 +5,20 @@
     "type": "git",
     "url": "git://github.com/owickstrom/purescript-hypertrout.git"
   },
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "output"
-  ],
+  "ignore": ["**/.*", "node_modules", "bower_components", "output"],
   "dependencies": {
     "purescript-prelude": "^4.1.1",
-    "purescript-console": "^4.2.0",
-    "purescript-hyper": "^0.10.0",
-    "purescript-trout": "^0.12.0"
+    "purescript-console": "^4.4.0",
+    "purescript-hyper": "^0.11.1",
+    "purescript-trout": "^0.12.3"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
     "purescript-spec": "^4.0.0",
     "purescript-spec-discovery": "^4.0.0",
-    "purescript-argonaut-generic": "^5.0.0"
+    "purescript-argonaut-generic": "^6.0.0"
   },
   "resolutions": {
-    "purescript-spec": "^4.0.0",
-    "purescript-typelevel-prelude": "^5.0.0"
+    "purescript-spec": "^4.0.0"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,8 +1,5 @@
-let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.2-20190715/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
-
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.2-20190715/src/packages.dhall sha256:906af79ba3aec7f429b107fd8d12e8a29426db8229d228c6f992b58151e2308e
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8/packages.dhall sha256:0e95ec11604dc8afc1b129c4d405dcc17290ce56d7d0665a0ff15617e32bbf03
 
 let overrides = {=}
 


### PR DESCRIPTION
This updates the Bower dependencies for anyone still on Bower to accommodate the recent updates to Hyper and Trout for `argonaut-codecs` v7.0.0.

Nothing needs to be done for the upcoming package set -- I tested that this library compiles with the next version of the set by using these overrides:

```dhall
  { argonaut = upstream.argonaut // { version = "v7.0.0" }
  , argonaut-codecs = upstream.argonaut-codecs // { version = "v7.0.0" }
  , argonaut-generic = upstream.argonaut-generic // { version = "v6.0.0" }
  , argonaut-traversals = upstream.argonaut-traversals // { version = "v8.0.0" }
  , trout = upstream.trout // { version = "v0.12.3" }
  }
```

But Bower users may need this to avoid issues with the major version bump in dependencies.